### PR TITLE
Bump duf to 0.8.0 & Update workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, rockylinux-8, centos-7, debian-buster, debian-stretch]
 
     steps:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ali Muhammad
+Copyright (c) 2022 Ali Muhammad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Available variables are listed below (located in `defaults/main.yml`):
 duf_app: duf
 duf_desired_state: present
 duf_version: 0.8.0
-duf_osarch: "linux_amd64"
+duf_os: "linux"
+duf_arch: "amd64"
 
 # For Debian/Ubuntu Family
-duf_debian_url: "https://github.com/muesli/{{ duf_app }}/releases/download/v{{ duf_version }}/{{ duf_app }}_{{ duf_version }}_{{ duf_osarch }}.deb"
+duf_debian_url: "https://github.com/muesli/{{ duf_app }}/releases/download/v{{ duf_version }}/{{ duf_app }}_{{ duf_version }}_{{ duf_os }}_{{ duf_arch }}.deb"
 
 # For EL Family
-duf_el_url: "https://github.com/muesli/{{ duf_app }}/releases/download/v{{ duf_version }}/{{ duf_app }}_{{ duf_version }}_{{ duf_osarch }}.rpm"
+duf_el_url: "https://github.com/muesli/{{ duf_app }}/releases/download/v{{ duf_version }}/{{ duf_app }}_{{ duf_version }}_{{ duf_os }}_{{ duf_arch }}.rpm"
 ```
 
 ### Variables table:
@@ -34,7 +35,8 @@ Variable          | Description
 duf_app           | Defines the app to install i.e. **duf**
 duf_desired_state | Defined to dynamically chose whether to install (i.e. either `present` or `latest`) or uninstall (i.e. `absent`) the package. Defaults to `present`.
 duf_version       | Defined to dynamically fetch the desired version to install. Defaults to: **0.8.0**
-duf_osarch        | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **"linux_amd64"**
+duf_os            | Defines OS type. Used for obtaining the correct type of binaries based on OS. Defaults to: **linux**
+duf_arch          | Defines Architecture type. Used for obtaining the correct type of binaries based on Architecture. Defaults to: **amd64**
 duf_debian_url    | Defines URL to download the 'deb' package from for Debian/Ubuntu family systems.
 duf_el_url        | Defines URL to download the 'rpm' package from for EL family systems.
 
@@ -69,7 +71,7 @@ For customizing behavior of role (i.e. different os architecture of **duf** pack
   roles:
     - darkwizard242.duf
   vars:
-    duf_osarch: "linux_arm64"
+    duf_arch: "arm64"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 ```yaml
 duf_app: duf
 duf_desired_state: present
-duf_version: 0.7.0
+duf_version: 0.8.0
 duf_osarch: "linux_amd64"
 
 # For Debian/Ubuntu Family
@@ -33,7 +33,7 @@ Variable          | Description
 ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------
 duf_app           | Defines the app to install i.e. **duf**
 duf_desired_state | Defined to dynamically chose whether to install (i.e. either `present` or `latest`) or uninstall (i.e. `absent`) the package. Defaults to `present`.
-duf_version       | Defined to dynamically fetch the desired version to install. Defaults to: **0.7.0**
+duf_version       | Defined to dynamically fetch the desired version to install. Defaults to: **0.8.0**
 duf_osarch        | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **"linux_amd64"**
 duf_debian_url    | Defines URL to download the 'deb' package from for Debian/Ubuntu family systems.
 duf_el_url        | Defines URL to download the 'rpm' package from for EL family systems.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 duf_app: duf
 duf_desired_state: present
-duf_version: 0.7.0
+duf_version: 0.8.0
 duf_osarch: "linux_amd64"
 
 # For Debian/Ubuntu Family

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,10 +4,11 @@
 duf_app: duf
 duf_desired_state: present
 duf_version: 0.8.0
-duf_osarch: "linux_amd64"
+duf_os: "linux"
+duf_arch: "amd64"
 
 # For Debian/Ubuntu Family
-duf_debian_url: "https://github.com/muesli/{{ duf_app }}/releases/download/v{{ duf_version }}/{{ duf_app }}_{{ duf_version }}_{{ duf_osarch }}.deb"
+duf_debian_url: "https://github.com/muesli/{{ duf_app }}/releases/download/v{{ duf_version }}/{{ duf_app }}_{{ duf_version }}_{{ duf_os }}_{{ duf_arch }}.deb"
 
 # For EL Family
-duf_el_url: "https://github.com/muesli/{{ duf_app }}/releases/download/v{{ duf_version }}/{{ duf_app }}_{{ duf_version }}_{{ duf_osarch }}.rpm"
+duf_el_url: "https://github.com/muesli/{{ duf_app }}/releases/download/v{{ duf_version }}/{{ duf_app }}_{{ duf_version }}_{{ duf_os }}_{{ duf_arch }}.rpm"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,3 +3,5 @@
   hosts: all
   roles:
     - role: darkwizard242.duf
+  vars:
+    ansible_python_interpreter: /usr/bin/python3

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,8 @@ lint: |
     ansible-lint
     flake8
 platforms:
-  - name: ${DISTRO:-ubuntu-18.04}
-    image: "darkwizard242/ansible:${DISTRO:-ubuntu-18.04}"
+  - name: ${DISTRO:-ubuntu-20.04}
+    image: "darkwizard242/ansible:${DISTRO:-ubuntu-20.04}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     pre_build_image: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.projectKey=ansible-role-duf
 sonar.organization=tech-overlord-github
 sonar.projectName=ansible-role-duf
 sonar.coverage.exclusions=**/**
+sonar.python.version=3
 #sonar.projectVersion=$TRAVIS_JOB_ID
 
 # =====================================================


### PR DESCRIPTION
- Bump `duf` to **0.8.0**
- Seperate out OS and ARCH into seperate vars
- Set `ansible_python_interpreter` var in molecule's converge playbook
- Bump container image in molecule config to ubuntu 20.04
- Update `build-and-test` github action workflow.
- Define `sonar.python.version=3` in sonarcloud config
- Utilize Rocky Linux 8 for EL 8 OS versions